### PR TITLE
Don't assume responses are vectors

### DIFF
--- a/elisp/org-db-v3-client.el
+++ b/elisp/org-db-v3-client.el
@@ -269,7 +269,7 @@ Skips remote Tramp files."
 
               ;; Classify files as existing, missing, or remote
               (dotimes (i count)
-                (let ((filename (alist-get 'filename (aref files i))))
+                (let ((filename (alist-get 'filename (elt files i))))
                   (cond
                    ((file-remote-p filename)
                     (push filename remote-files))


### PR DESCRIPTION
* elisp/org-db-v3-client.el (org-db-v3-reindex-database): json-array-type might be set to 'list instead of 'vector, so use elt instead of aref.